### PR TITLE
WIP enhance curl retries

### DIFF
--- a/runner
+++ b/runner
@@ -3,7 +3,7 @@ set -e
 [[ ! -z "$DEBUG" ]] && set -x
 trap "exit" INT
 
-[[ -z "$CURL_RETRY" ]] && CURL_RETRY="--retry 6 --retry-delay 10"
+[[ -z "$CURL_RETRY" ]] && CURL_RETRY="--retry 6"
 
 [[ -z "$CURL_INITIAL_WAIT" ]] && CURL_INITIAL_WAIT=10
 sleep $CURL_INITIAL_WAIT


### PR DESCRIPTION
In tests it would be quite useful to retry on 404. Services tend to start, then you fill them with test data, then your tests can pass.

https://curl.haxx.se/docs/manpage.html clearly states that only "HTTP 5xx response code" is considered transient.

An option to retry on connection refused, i.e. when the service hasn't started yet, would also lead to more robust tests.